### PR TITLE
Add call to wg.Wait() before returning from Serve(), fix server tests

### DIFF
--- a/server.go
+++ b/server.go
@@ -44,6 +44,7 @@ func (s *GracefulServer) Serve(listener net.Listener, handler http.Handler) erro
 	if err == nil {
 		return nil
 	} else if _, ok := err.(listenerAlreadyClosed); ok {
+		s.wg.Wait()
 		return nil
 	}
 	return err

--- a/test_helper.go
+++ b/test_helper.go
@@ -2,6 +2,7 @@ package manners
 
 import (
 	"net/http"
+	"time"
 )
 
 // A response handler that blocks until it receives a signal; simulates an
@@ -19,7 +20,8 @@ type blockingHandler struct {
 
 func (h *blockingHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	h.ready <- true
-	<-h.done
+	time.Sleep(1e2)
+	h.done <- true
 }
 
 // A response handler that does nothing.


### PR DESCRIPTION
Though the readme states clearly that "_the call to server.ListenAndServe will stop blocking when all the requests are finished_", this doesn't seem to be the case. I've put together multiple tests, and at least in Go 1.2, as soon as the listener is closed and `Accept()` starts returning an error, `http.Serve` returns with that error immediately. Is it possible this is new behavior in Go 1.2?

In any case, `manners` isn't calling  `wg.Wait()` anywhere, so the process exits and all in-flight routines are killed. Essentially, it's currently doing nothing, as far as I can tell. The tests in `server_test.go` pass because the process is still running when the test completes, meaning the goroutines eventually finish even after the server has shut down, even though in most environments they would be killed.

This patch adds a call to `wg.Wait()` before returning from `Serve()` when the listener has been closed, and fixes the test to actually check whether the request has completed before the server shuts down. Tested and working well with Go 1.2.
