### PR TITLE
Disable keep-alives in shutdown hander

### DIFF
--- a/server.go
+++ b/server.go
@@ -39,7 +39,10 @@ func (s *GracefulServer) ListenAndServe(addr string, handler http.Handler) error
 
 // Similar to http.Serve. The listener passed must wrap a GracefulListener.
 func (s *GracefulServer) Serve(listener net.Listener, handler http.Handler) error {
-	s.shutdownHandler = func() { listener.Close() }
+	s.shutdownHandler = func() {
+		s.InnerServer.SetKeepAlivesEnabled(false)
+		listener.Close()
+	}
 	s.listenForShutdown()
 	s.InnerServer.Handler = handler
 	s.InnerServer.ConnState = func(conn net.Conn, newState http.ConnState) {

--- a/server_test.go
+++ b/server_test.go
@@ -48,6 +48,7 @@ func TestGracefulness(t *testing.T) {
 // Tests that the server begins to shut down when told to and does not accept
 // new requests
 func TestShutdown(t *testing.T) {
+	url := "http://localhost:7100"
 	handler := newTestHandler()
 	server := NewServer()
 	exited := make(chan bool)
@@ -60,10 +61,18 @@ func TestShutdown(t *testing.T) {
 		exited <- true
 	}()
 
+	if r,_ := http.Get(url); r.Close {
+		t.Fatal("Keep-Alives were disabled pre-shutdown")
+	}
+
 	server.Shutdown <- true
 
+	if r,_ := http.Get(url); !r.Close  {
+		t.Fatal("Keep-Alives were enabled post-shutdown")
+	}
+
 	<-exited
-	_, err := http.Get("http://localhost:7100")
+	_, err := http.Get(url)
 
 	if err == nil {
 		t.Fatal("Did not receive an error when trying to connect to server.")


### PR DESCRIPTION
If a persistent connection is before shutdown, the client will
continue to be able to make requests to the server and block
the shutdown because the `ConnState` never changes to `http.StateClosed`.
This disables keep-alives on the server during the shutdown routine,
which is recommended in the net/http docs for servers in the process
of shutting down.
