### PR TITLE
Reject requests via kept alive connections after close

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -19,9 +19,13 @@ type client struct {
 	addr        net.Addr
 	connected   chan error
 	sendrequest chan bool
-	idle        chan error
-	idlerelease chan bool
+	response    chan *rawResponse
 	closed      chan bool
+}
+
+type rawResponse struct {
+	body []string
+	err  error
 }
 
 func (c *client) Run() {
@@ -39,19 +43,21 @@ func (c *client) Run() {
 		for <-c.sendrequest {
 			_, err = conn.Write([]byte("GET / HTTP/1.1\nHost: localhost:8000\n\n"))
 			if err != nil {
-				c.idle <- err
+				c.response <- &rawResponse{err: err}
 			}
 			// Read response; no content
 			scanner := bufio.NewScanner(conn)
+			var lines []string
 			for scanner.Scan() {
 				// our null handler doesn't send a body, so we know the request is
 				// done when we reach the blank line after the headers
-				if scanner.Text() == "" {
+				line := scanner.Text()
+				if line == "" {
 					break
 				}
+				lines = append(lines, line)
 			}
-			c.idle <- scanner.Err()
-			<-c.idlerelease
+			c.response <- &rawResponse{lines, scanner.Err()}
 		}
 		conn.Close()
 		ioutil.ReadAll(conn)
@@ -65,8 +71,7 @@ func newClient(addr net.Addr, tls bool) *client {
 		tls:         tls,
 		connected:   make(chan error),
 		sendrequest: make(chan bool),
-		idle:        make(chan error),
-		idlerelease: make(chan bool),
+		response:    make(chan *rawResponse),
 		closed:      make(chan bool),
 	}
 }

--- a/server.go
+++ b/server.go
@@ -64,8 +64,8 @@ type GracefulServer struct {
 	shutdownFinished chan bool
 	wg               waitGroup
 
-	lcsmu         sync.RWMutex
-	lastConnState map[net.Conn]http.ConnState
+	lcsmu       sync.RWMutex
+	connections map[net.Conn]bool
 
 	up chan net.Listener // Only used by test code.
 }
@@ -78,7 +78,7 @@ func NewWithServer(s *http.Server) *GracefulServer {
 		shutdown:         make(chan bool),
 		shutdownFinished: make(chan bool, 1),
 		wg:               new(sync.WaitGroup),
-		lastConnState:    make(map[net.Conn]http.ConnState),
+		connections:      make(map[net.Conn]bool),
 	}
 }
 
@@ -142,63 +142,64 @@ func (s *GracefulServer) ListenAndServeTLS(certFile, keyFile string) error {
 
 // Serve provides a graceful equivalent net/http.Server.Serve.
 func (s *GracefulServer) Serve(listener net.Listener) error {
-	var closing int32
+	// Wrap the server HTTP handler into graceful one, that will close kept
+	// alive connections if a new request is received after shutdown.
+	gracefulHandler := newGracefulHandler(s.Server.Handler)
+	s.Server.Handler = gracefulHandler
 
+	// Start a goroutine that waits for a shutdown signal and will stop the
+	// listener when it receives the signal. That in turn will result in
+	// unblocking of the http.Serve call.
 	go func() {
 		s.shutdown <- true
 		close(s.shutdown)
-		atomic.StoreInt32(&closing, 1)
+		gracefulHandler.Close()
 		s.Server.SetKeepAlivesEnabled(false)
 		listener.Close()
-		s.shutdownFinished <- true
 	}()
 
 	originalConnState := s.Server.ConnState
 
-	// s.ConnState is invoked by the net/http.Server every time a connectiion
+	// s.ConnState is invoked by the net/http.Server every time a connection
 	// changes state. It keeps track of each connection's state over time,
 	// enabling manners to handle persisted connections correctly.
 	s.ConnState = func(conn net.Conn, newState http.ConnState) {
 		s.lcsmu.RLock()
-		lastConnState := s.lastConnState[conn]
+		protected := s.connections[conn]
 		s.lcsmu.RUnlock()
 
 		switch newState {
 
-		// New connection -> StateNew
 		case http.StateNew:
+			// New connection -> StateNew
+			protected = true
 			s.StartRoutine()
 
-			// (StateNew, StateIdle) -> StateActive
 		case http.StateActive:
-			// The connection transitioned from idle back to active
-			if lastConnState == http.StateIdle {
+			// (StateNew, StateIdle) -> StateActive
+			if gracefulHandler.IsClosed() {
+				conn.Close()
+				break
+			}
+
+			if !protected {
+				protected = true
 				s.StartRoutine()
 			}
 
-			// StateActive -> StateIdle
-			// Immediately close newly idle connections; if not they may make
-			// one more request before SetKeepAliveEnabled(false) takes effect.
-		case http.StateIdle:
-			if atomic.LoadInt32(&closing) == 1 {
-				conn.Close()
-			}
-			s.FinishRoutine()
-
-			// (StateNew, StateActive, StateIdle) -> (StateClosed, StateHiJacked)
-			// If the connection was idle we do not need to decrement the counter.
-		case http.StateClosed, http.StateHijacked:
-			if lastConnState != http.StateIdle {
+		default:
+			// (StateNew, StateActive) -> (StateIdle, StateClosed, StateHiJacked)
+			if protected {
 				s.FinishRoutine()
+				protected = false
 			}
-
 		}
 
 		s.lcsmu.Lock()
 		if newState == http.StateClosed || newState == http.StateHijacked {
-			delete(s.lastConnState, conn)
+			delete(s.connections, conn)
 		} else {
-			s.lastConnState[conn] = newState
+			s.connections[conn] = protected
 		}
 		s.lcsmu.Unlock()
 
@@ -214,14 +215,14 @@ func (s *GracefulServer) Serve(listener net.Listener) error {
 	}
 
 	err := s.Server.Serve(listener)
-
-	// This block is reached when the server has received a shut down command
-	// or a real error happened.
-	if err == nil || atomic.LoadInt32(&closing) == 1 {
-		s.wg.Wait()
-		return nil
+	// An error returned on shutdown is not worth reporting.
+	if err != nil && gracefulHandler.IsClosed() {
+		err = nil
 	}
 
+	// Wait for pending requests to complete regardless the Serve result.
+	s.wg.Wait()
+	s.shutdownFinished <- true
 	return err
 }
 
@@ -236,4 +237,36 @@ func (s *GracefulServer) StartRoutine() {
 // StartRoutine().
 func (s *GracefulServer) FinishRoutine() {
 	s.wg.Done()
+}
+
+// gracefulHandler is used by GracefulServer to prevent calling ServeHTTP on
+// to be closed kept-alive connections during the server shutdown.
+type gracefulHandler struct {
+	closed  int32 // accessed atomically.
+	wrapped http.Handler
+}
+
+func newGracefulHandler(wrapped http.Handler) *gracefulHandler {
+	return &gracefulHandler{
+		wrapped: wrapped,
+	}
+}
+
+func (gh *gracefulHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if atomic.LoadInt32(&gh.closed) == 0 {
+		gh.wrapped.ServeHTTP(w, r)
+		return
+	}
+	r.Body.Close()
+	// Server is shutting down at this moment, and the connection that this
+	// handler is being called on is about to be closed. So we do not need to
+	// actually execute the handler logic.
+}
+
+func (gh *gracefulHandler) Close() {
+	atomic.StoreInt32(&gh.closed, 1)
+}
+
+func (gh *gracefulHandler) IsClosed() bool {
+	return atomic.LoadInt32(&gh.closed) == 1
 }

--- a/test_helpers/listener.go
+++ b/test_helpers/listener.go
@@ -1,8 +1,8 @@
 package test_helpers
 
 import (
-  "net"
-  "errors"
+	"errors"
+	"net"
 )
 
 type Listener struct {
@@ -11,10 +11,10 @@ type Listener struct {
 }
 
 func NewListener() *Listener {
-  return &Listener{
-    make(chan bool, 1),
-    make(chan bool, 1),
-  }
+	return &Listener{
+		make(chan bool, 1),
+		make(chan bool, 1),
+	}
 }
 
 func (l *Listener) Addr() net.Addr {


### PR DESCRIPTION
### Problem
After a graceful server is stopped, kept alive connections are left hanging. Each of them allow one more request to be processed, after that they are closed thanks to  `SetKeepAlivesEnabled(false)`. But that one request (per connection) can still screw things up if e.g. it sends to a channel that you already closed since supposedly the http server has stopped gracefully.

### Solution
Graceful server should ignore requests received via kept alive connections after server shutdown. 