### PR TITLE
Uplift from mailgun/manners fork

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -1,0 +1,155 @@
+package manners
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// NewListener wraps an existing listener for use with
+// GracefulServer.
+//
+// Note that you generally don't need to use this directly as
+// GracefulServer will automatically wrap any non-graceful listeners
+// supplied to it.
+func NewListener(l net.Listener) *GracefulListener {
+	return &GracefulListener{
+		listener: l,
+		mutex:    &sync.RWMutex{},
+		open:     true,
+	}
+}
+
+// A GracefulListener differs from a standard net.Listener in one way: if
+// Accept() is called after it is gracefully closed, it returns a
+// listenerAlreadyClosed error. The GracefulServer will ignore this error.
+type GracefulListener struct {
+	listener net.Listener
+	open     bool
+	mutex    *sync.RWMutex
+}
+
+func (l *GracefulListener) isClosed() bool {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+	return !l.open
+}
+
+func (l *GracefulListener) Addr() net.Addr {
+	return l.listener.Addr()
+}
+
+// Accept implements the Accept method in the Listener interface.
+func (l *GracefulListener) Accept() (net.Conn, error) {
+	conn, err := l.listener.Accept()
+	if err != nil {
+		if l.isClosed() {
+			err = fmt.Errorf("listener already closed: err=(%s)", err)
+		}
+		return nil, err
+	}
+	return conn, nil
+}
+
+// Close tells the wrapped listener to stop listening.  It is idempotent.
+func (l *GracefulListener) Close() error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if !l.open {
+		return nil
+	}
+	l.open = false
+	return l.listener.Close()
+}
+
+func (l *GracefulListener) GetFile() (*os.File, error) {
+	return getListenerFile(l.listener)
+}
+
+func (l *GracefulListener) Clone() (net.Listener, error) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if !l.open {
+		return nil, errors.New("listener is already closed")
+	}
+
+	file, err := l.GetFile()
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	fl, err := net.FileListener(file)
+	if nil != err {
+		return nil, err
+	}
+	return fl, nil
+}
+
+// A listener implements a network listener (net.Listener) for TLS connections.
+// direct lift from crypto/tls.go
+type TLSListener struct {
+	net.Listener
+	config *tls.Config
+}
+
+// Accept waits for and returns the next incoming TLS connection.
+// The returned connection c is a *tls.Conn.
+func (l *TLSListener) Accept() (c net.Conn, err error) {
+	c, err = l.Listener.Accept()
+	if err != nil {
+		return
+	}
+	c = tls.Server(c, l.config)
+	return
+}
+
+// NewListener creates a Listener which accepts connections from an inner
+// Listener and wraps each connection with Server.
+// The configuration config must be non-nil and must have
+// at least one certificate.
+func NewTLSListener(inner net.Listener, config *tls.Config) net.Listener {
+	l := new(TLSListener)
+	l.Listener = inner
+	l.config = config
+	return l
+}
+
+// TCPKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+//
+// direct lift from net/http/server.go
+type TCPKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln TCPKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}
+
+func getListenerFile(listener net.Listener) (*os.File, error) {
+	switch t := listener.(type) {
+	case *net.TCPListener:
+		return t.File()
+	case *net.UnixListener:
+		return t.File()
+	case TCPKeepAliveListener:
+		return t.TCPListener.File()
+	case *TLSListener:
+		return getListenerFile(t.Listener)
+	}
+	return nil, fmt.Errorf("Unsupported listener: %T", listener)
+}

--- a/server.go
+++ b/server.go
@@ -44,9 +44,23 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"sync/atomic"
+	"unsafe"
 )
+
+// StateHandler can be called by the server if the state of the connection changes.
+// Notice that it passed previous state and the new state as parameters.
+type StateHandler func(net.Conn, http.ConnState, http.ConnState)
+
+// Options used by NewWithOptions to provide parameters for a GracefulServer
+// instance to be created.
+type Options struct {
+	Server       *http.Server
+	StateHandler StateHandler
+	Listener     net.Listener
+}
 
 // A GracefulServer maintains a WaitGroup that counts how many in-flight
 // requests the server is handling. When it receives a shutdown signal,
@@ -56,77 +70,93 @@ import (
 // GracefulServer embeds the underlying net/http.Server making its non-override
 // methods and properties avaiable.
 //
-// It must be initialized by calling NewWithServer.
+// It must be initialized by calling NewServer or NewWithServer
 type GracefulServer struct {
 	*http.Server
-
 	shutdown         chan bool
 	shutdownFinished chan bool
 	wg               waitGroup
 	routinesCount    int32
-
-	lcsmu       sync.RWMutex
-	connections map[net.Conn]bool
+	listener         *GracefulListener
+	stateHandler     StateHandler
+	connToProps      map[net.Conn]connProperties
+	connToPropsMtx   sync.RWMutex
 
 	up chan net.Listener // Only used by test code.
 }
 
 // NewServer creates a new GracefulServer.
 func NewServer() *GracefulServer {
-	return NewWithServer(new(http.Server))
+	return NewWithOptions(Options{})
 }
 
 // NewWithServer wraps an existing http.Server object and returns a
 // GracefulServer that supports all of the original Server operations.
 func NewWithServer(s *http.Server) *GracefulServer {
+	return NewWithOptions(Options{Server: s})
+}
+
+// NewWithOptions creates a GracefulServer instance with the specified options.
+func NewWithOptions(o Options) *GracefulServer {
+	var listener *GracefulListener
+	if o.Listener != nil {
+		g, ok := o.Listener.(*GracefulListener)
+		if !ok {
+			listener = NewListener(o.Listener)
+		} else {
+			listener = g
+		}
+	}
+	if o.Server == nil {
+		o.Server = new(http.Server)
+	}
 	return &GracefulServer{
-		Server:           s,
+		Server:           o.Server,
+		listener:         listener,
+		stateHandler:     o.StateHandler,
 		shutdown:         make(chan bool),
 		shutdownFinished: make(chan bool, 1),
 		wg:               new(sync.WaitGroup),
-		routinesCount:    0,
-		connections:      make(map[net.Conn]bool),
+		connToProps:      make(map[net.Conn]connProperties),
 	}
 }
 
 // Close stops the server from accepting new requets and begins shutting down.
 // It returns true if it's the first time Close is called.
-func (s *GracefulServer) Close() bool {
-	return <-s.shutdown
+func (gs *GracefulServer) Close() bool {
+	return <-gs.shutdown
 }
 
 // BlockingClose is similar to Close, except that it blocks until the last
 // connection has been closed.
-func (s *GracefulServer) BlockingClose() bool {
-	result := s.Close()
-	<-s.shutdownFinished
+func (gs *GracefulServer) BlockingClose() bool {
+	result := gs.Close()
+	<-gs.shutdownFinished
 	return result
 }
 
 // ListenAndServe provides a graceful equivalent of net/http.Serve.ListenAndServe.
-func (s *GracefulServer) ListenAndServe() error {
-	addr := s.Addr
-	if addr == "" {
-		addr = ":http"
+func (gs *GracefulServer) ListenAndServe() error {
+	if gs.listener == nil {
+		oldListener, err := net.Listen("tcp", gs.Addr)
+		if err != nil {
+			return err
+		}
+		gs.listener = NewListener(oldListener.(*net.TCPListener))
 	}
-	listener, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
-	}
-
-	return s.Serve(listener)
+	return gs.Serve(gs.listener)
 }
 
 // ListenAndServeTLS provides a graceful equivalent of net/http.Serve.ListenAndServeTLS.
-func (s *GracefulServer) ListenAndServeTLS(certFile, keyFile string) error {
+func (gs *GracefulServer) ListenAndServeTLS(certFile, keyFile string) error {
 	// direct lift from net/http/server.go
-	addr := s.Addr
+	addr := gs.Addr
 	if addr == "" {
 		addr = ":https"
 	}
 	config := &tls.Config{}
-	if s.TLSConfig != nil {
-		*config = *s.TLSConfig
+	if gs.TLSConfig != nil {
+		*config = *gs.TLSConfig
 	}
 	if config.NextProtos == nil {
 		config.NextProtos = []string{"http/1.1"}
@@ -139,48 +169,96 @@ func (s *GracefulServer) ListenAndServeTLS(certFile, keyFile string) error {
 		return err
 	}
 
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
+	return gs.ListenAndServeTLSWithConfig(config)
+}
+
+// ListenAndServeTLS provides a graceful equivalent of net/http.Serve.ListenAndServeTLS.
+func (gs *GracefulServer) ListenAndServeTLSWithConfig(config *tls.Config) error {
+	addr := gs.Addr
+	if addr == "" {
+		addr = ":https"
 	}
 
-	return s.Serve(tls.NewListener(ln, config))
+	if gs.listener == nil {
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			return err
+		}
+
+		tlsListener := NewTLSListener(TCPKeepAliveListener{ln.(*net.TCPListener)}, config)
+		gs.listener = NewListener(tlsListener)
+	}
+	return gs.Serve(gs.listener)
+}
+
+func (gs *GracefulServer) GetFile() (*os.File, error) {
+	return gs.listener.GetFile()
+}
+
+func (gs *GracefulServer) HijackListener(s *http.Server, config *tls.Config) (*GracefulServer, error) {
+	listenerUnsafePtr := unsafe.Pointer(gs.listener)
+	listener, err := (*GracefulListener)(atomic.LoadPointer(&listenerUnsafePtr)).Clone()
+	if err != nil {
+		return nil, err
+	}
+
+	if config != nil {
+		listener = NewTLSListener(TCPKeepAliveListener{listener.(*net.TCPListener)}, config)
+	}
+
+	other := NewWithServer(s)
+	other.listener = NewListener(listener)
+	return other, nil
 }
 
 // Serve provides a graceful equivalent net/http.Server.Serve.
-func (s *GracefulServer) Serve(listener net.Listener) error {
+//
+// If listener is not an instance of *GracefulListener it will be wrapped
+// to become one.
+func (gs *GracefulServer) Serve(listener net.Listener) error {
+	// Accept a net.Listener to preserve the interface compatibility with the
+	// standard http.Server. If it is not a GracefulListener then wrap it into
+	// one.
+	gracefulListener, ok := listener.(*GracefulListener)
+	if !ok {
+		gracefulListener = NewListener(listener)
+		listener = gracefulListener
+	}
+	listenerUnsafePtr := unsafe.Pointer(gs.listener)
+	atomic.StorePointer(&listenerUnsafePtr, unsafe.Pointer(gracefulListener))
+
 	// Wrap the server HTTP handler into graceful one, that will close kept
 	// alive connections if a new request is received after shutdown.
-	gracefulHandler := newGracefulHandler(s.Server.Handler)
-	s.Server.Handler = gracefulHandler
+	gracefulHandler := newGracefulHandler(gs.Server.Handler)
+	gs.Server.Handler = gracefulHandler
 
 	// Start a goroutine that waits for a shutdown signal and will stop the
 	// listener when it receives the signal. That in turn will result in
 	// unblocking of the http.Serve call.
 	go func() {
-		s.shutdown <- true
-		close(s.shutdown)
+		gs.shutdown <- true
+		close(gs.shutdown)
 		gracefulHandler.Close()
-		s.Server.SetKeepAlivesEnabled(false)
-		listener.Close()
+		gs.Server.SetKeepAlivesEnabled(false)
+		gracefulListener.Close()
 	}()
 
-	originalConnState := s.Server.ConnState
+	originalConnState := gs.Server.ConnState
 
 	// s.ConnState is invoked by the net/http.Server every time a connection
 	// changes state. It keeps track of each connection's state over time,
 	// enabling manners to handle persisted connections correctly.
-	s.ConnState = func(conn net.Conn, newState http.ConnState) {
-		s.lcsmu.RLock()
-		protected := s.connections[conn]
-		s.lcsmu.RUnlock()
+	gs.ConnState = func(conn net.Conn, newState http.ConnState) {
+		gs.connToPropsMtx.RLock()
+		connProps := gs.connToProps[conn]
+		gs.connToPropsMtx.RUnlock()
 
 		switch newState {
 
 		case http.StateNew:
 			// New connection -> StateNew
-			protected = true
-			s.StartRoutine()
+			connProps.protected = true
+			gs.StartRoutine()
 
 		case http.StateActive:
 			// (StateNew, StateIdle) -> StateActive
@@ -189,26 +267,31 @@ func (s *GracefulServer) Serve(listener net.Listener) error {
 				break
 			}
 
-			if !protected {
-				protected = true
-				s.StartRoutine()
+			if !connProps.protected {
+				connProps.protected = true
+				gs.StartRoutine()
 			}
 
 		default:
 			// (StateNew, StateActive) -> (StateIdle, StateClosed, StateHiJacked)
-			if protected {
-				s.FinishRoutine()
-				protected = false
+			if connProps.protected {
+				gs.FinishRoutine()
+				connProps.protected = false
 			}
 		}
 
-		s.lcsmu.Lock()
-		if newState == http.StateClosed || newState == http.StateHijacked {
-			delete(s.connections, conn)
-		} else {
-			s.connections[conn] = protected
+		if gs.stateHandler != nil {
+			gs.stateHandler(conn, connProps.state, newState)
 		}
-		s.lcsmu.Unlock()
+		connProps.state = newState
+
+		gs.connToPropsMtx.Lock()
+		if newState == http.StateClosed || newState == http.StateHijacked {
+			delete(gs.connToProps, conn)
+		} else {
+			gs.connToProps[conn] = connProps
+		}
+		gs.connToPropsMtx.Unlock()
 
 		if originalConnState != nil {
 			originalConnState(conn, newState)
@@ -217,40 +300,40 @@ func (s *GracefulServer) Serve(listener net.Listener) error {
 
 	// A hook to allow the server to notify others when it is ready to receive
 	// requests; only used by tests.
-	if s.up != nil {
-		s.up <- listener
+	if gs.up != nil {
+		gs.up <- listener
 	}
 
-	err := s.Server.Serve(listener)
+	err := gs.Server.Serve(listener)
 	// An error returned on shutdown is not worth reporting.
 	if err != nil && gracefulHandler.IsClosed() {
 		err = nil
 	}
 
 	// Wait for pending requests to complete regardless the Serve result.
-	s.wg.Wait()
-	s.shutdownFinished <- true
+	gs.wg.Wait()
+	gs.shutdownFinished <- true
 	return err
 }
 
 // StartRoutine increments the server's WaitGroup. Use this if a web request
 // starts more goroutines and these goroutines are not guaranteed to finish
 // before the request.
-func (s *GracefulServer) StartRoutine() {
-	s.wg.Add(1)
-	atomic.AddInt32(&s.routinesCount, 1)
+func (gs *GracefulServer) StartRoutine() {
+	gs.wg.Add(1)
+	atomic.AddInt32(&gs.routinesCount, 1)
 }
 
 // FinishRoutine decrements the server's WaitGroup. Use this to complement
 // StartRoutine().
-func (s *GracefulServer) FinishRoutine() {
-	s.wg.Done()
-	atomic.AddInt32(&s.routinesCount, -1)
+func (gs *GracefulServer) FinishRoutine() {
+	gs.wg.Done()
+	atomic.AddInt32(&gs.routinesCount, -1)
 }
 
 // RoutinesCount returns the number of currently running routines
-func (s *GracefulServer) RoutinesCount() int {
-	return int(atomic.LoadInt32(&s.routinesCount))
+func (gs *GracefulServer) RoutinesCount() int {
+	return int(atomic.LoadInt32(&gs.routinesCount))
 }
 
 // gracefulHandler is used by GracefulServer to prevent calling ServeHTTP on
@@ -283,4 +366,14 @@ func (gh *gracefulHandler) Close() {
 
 func (gh *gracefulHandler) IsClosed() bool {
 	return atomic.LoadInt32(&gh.closed) == 1
+}
+
+// connProperties is used to keep track of various properties of connections
+// maintained by a gracefulServer.
+type connProperties struct {
+	// Last known connection state.
+	state http.ConnState
+	// Tells whether the connection is going to defer server shutdown until
+	// the current HTTP request is completed.
+	protected bool
 }

--- a/test_helpers/wait_group.go
+++ b/test_helpers/wait_group.go
@@ -4,25 +4,29 @@ import "sync"
 
 type WaitGroup struct {
 	sync.Mutex
-	Count      int
-	WaitCalled chan int
+	Count        int
+	WaitCalled   chan int
+	CountChanged chan int
 }
 
 func NewWaitGroup() *WaitGroup {
 	return &WaitGroup{
-		WaitCalled: make(chan int, 1),
+		WaitCalled:   make(chan int, 1),
+		CountChanged: make(chan int, 1024),
 	}
 }
 
 func (wg *WaitGroup) Add(delta int) {
 	wg.Lock()
 	wg.Count++
+	wg.CountChanged <- wg.Count
 	wg.Unlock()
 }
 
 func (wg *WaitGroup) Done() {
 	wg.Lock()
 	wg.Count--
+	wg.CountChanged <- wg.Count
 	wg.Unlock()
 }
 


### PR DESCRIPTION
This PR tries to bring all features implemented in the [mailgun/manners](https://github.com/mailgun/manners) fork to the upstream so that projects like [vulcand](https://github.com/vulcand/vulcand) can stop depending on the fork and start using the upstream.

The changes are:
- Added support for TLS listener hijack and update;
- Added capability to specify a state handler that if provided is called on connection state transitions and passed both old and new connection state;
- Added `GetFile` function that returns a listener socket file handler that can be used to handover to a child process during hot server code reload;
- Added a couple of `New...` functions for convenience; 

The changes have been originally implemented by @klizhentas, I have just rebased them to the upstream master.
